### PR TITLE
Migrate Next non-macOS CI to CodeBuild

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,8 +1,8 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-06"
-lastReviewedCommit: "32758423c199da08cf1a9c26c5e2dba5be6c8f69"
-lastReviewedNote: 'Reviewed for Next #1035 after Edge #407/#409 and root #1021/#1022: import exact Edge main ceff9c4 with legacy RPC/fallback compatibility; Database e988 snapshot and restore proof remain unchanged. Both pin contracts advance together; the normal committed push owns fresh full-gate proof.'
+lastReviewedAt: "2026-09-08"
+lastReviewedCommit: "5fe90293372adb1ba25fbf2d7dda06ba99bd94e9"
+lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.
 # AGENTS.md keeps the entry-level repo contract and minimal execution summary.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-09-08"
-lastReviewedCommit: "5fe90293372adb1ba25fbf2d7dda06ba99bd94e9"
+lastReviewedAt: "2026-09-09"
+lastReviewedCommit: "86a5075e35e01f6e2aa6137a8510afa1b68a7f22"
 lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   ai-doc-lint:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -3,6 +3,23 @@ name: ai-doc-lint
 on:
   workflow_dispatch:
     inputs:
+      provider:
+        description: Manual comparison provider.
+        type: choice
+        default: codebuild
+        options: [codebuild, hosted]
+      cache_enabled:
+        description: Cache the pnpm store; disable for the no-cache comparison.
+        type: boolean
+        default: true
+      cache_epoch:
+        description: Provider-specific experiment namespace; reuse for warm samples.
+        type: string
+        default: ''
+      ref:
+        description: Optional exact candidate SHA for controlled comparison.
+        type: string
+        default: ''
       base_ref:
         description: Base ref for the manual docpact comparison.
         required: false
@@ -13,23 +30,34 @@ permissions:
 
 jobs:
   ai-doc-lint:
-    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ${{ inputs.provider == 'hosted' && 'ubuntu-latest' || format('codebuild-tiangong-ci-next-linux-{0}-{1}', github.run_id, github.run_attempt) }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
 
       - name: Fetch branches
         run: git fetch --force origin '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: Bind comparison cache namespace
+        if: inputs.cache_epoch != ''
+        env:
+          EXPECTED_SHA: ${{ inputs.ref }}
+          BENCHMARK_PROVIDER: ${{ inputs.provider }}
+          CACHE_EPOCH: ${{ inputs.cache_epoch }}
+        run: >-
+          node -e "const fs=require('node:fs'),cp=require('node:child_process'); const sha=process.env.EXPECTED_SHA; if(!/^[0-9a-f]{40}$/.test(sha)||cp.execFileSync('git',['rev-parse','HEAD'],{encoding:'utf8'}).trim()!==sha) throw Error('Exact candidate mismatch'); fs.mkdirSync('.local/test-logs',{recursive:true}); fs.writeFileSync('.local/test-logs/ci-benchmark-cache-key',Buffer.concat([fs.readFileSync('pnpm-lock.yaml'),Buffer.from(JSON.stringify({provider:process.env.BENCHMARK_PROVIDER,epoch:process.env.CACHE_EPOCH}))]));"
 
       - name: Set up pnpm and Node.js
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
           version: 11.24.0
           runtime: node@24.19.0
-          cache: true
+          cache: ${{ inputs.cache_enabled }}
+          cache-dependency-path: ${{ inputs.cache_epoch != '' && '.local/test-logs/ci-benchmark-cache-key' || 'pnpm-lock.yaml' }}
           install: false
 
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   release-context:
     name: Release Context
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       release_base: ${{ steps.release.outputs.release_base }}
       release_head: ${{ steps.release.outputs.release_head }}
@@ -188,7 +188,7 @@ jobs:
       - release-context
       - release-gate
     if: ${{ always() && needs.release-context.outputs.should_release == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Require the dev candidate proof or an explicit recovery full gate
@@ -231,7 +231,7 @@ jobs:
       - release-qualified
     if: >-
       ${{ !cancelled() && needs.release-context.result == 'success' && needs.release-context.outputs.should_release == 'true' && needs.release-qualified.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Check out exact release candidate
@@ -288,7 +288,7 @@ jobs:
       - release-tag
     if: >-
       ${{ !cancelled() && needs.release-context.result == 'success' && needs.release-context.outputs.should_release == 'true' && needs.release-qualified.result == 'success' && needs.release-tag.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
 
@@ -362,7 +362,7 @@ jobs:
       - release-tag
     if: >-
       ${{ !cancelled() && needs.release-context.result == 'success' && needs.release-context.outputs.should_release == 'true' && needs.release-qualified.result == 'success' && needs.release-tag.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
     env:
       EDGEONE_OUTPUT_DIR: dist
       EDGEONE_PROJECT_NAME: tiangong-lca-next-upload
@@ -431,19 +431,22 @@ jobs:
       - release-tag
     if: >-
       ${{ !cancelled() && needs.release-context.result == 'success' && needs.release-context.outputs.should_release == 'true' && needs.release-qualified.result == 'success' && needs.release-draft.result == 'success' && needs.release-tag.result == 'success' }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os == 'macos-latest' && matrix.os || format('codebuild-tiangong-ci-next-{0}-{1}-{2}', matrix.executor, github.run_id, github.run_attempt) }}
 
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
             arch: x64
+            executor: linux
           - os: windows-latest
             arch: x64
+            executor: windows
           - os: macos-latest
             arch: arm64
           - os: ubuntu-24.04-arm
             arch: arm64
+            executor: arm
 
     steps:
       - name: Check out Git repository
@@ -478,7 +481,7 @@ jobs:
       - release
     if: >-
       ${{ !cancelled() && needs.release-context.result == 'success' && needs.release-context.outputs.should_release == 'true' && needs.release-draft.result == 'success' && needs.release.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Verify release identity and assets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   build-and-deploy:
     name: Build and Deploy Web App
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
     env:
       EDGEONE_OUTPUT_DIR: dist
       EDGEONE_PROJECT_NAME: tiangong-lca-next-upload

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -2,16 +2,16 @@ name: Gitleaks Security Scan
 
 on:
   push:
-    branches: [ main, master, dev*, ]  # Triggered on push to main and development branches
+    branches: [main, master, dev*] # Triggered on push to main and development branches
   pull_request:
-    branches: [ main, master ]        # Triggered on PR to main branches
+    branches: [main, master] # Triggered on PR to main branches
   schedule:
-    - cron: '0 0 * * 0'              # Scan every Sunday at UTC 00:00
+    - cron: '0 0 * * 0' # Scan every Sunday at UTC 00:00
 
 jobs:
   scan:
     name: Gitleaks Security Scan
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/i18n-semantic-e2e.yml
+++ b/.github/workflows/i18n-semantic-e2e.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   semantic-qualification:
     name: Manual Hermetic Semantic Qualification
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-docker-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/i18n-semantic-e2e.yml
+++ b/.github/workflows/i18n-semantic-e2e.yml
@@ -3,6 +3,19 @@ name: I18n semantic E2E
 on:
   workflow_dispatch:
     inputs:
+      provider:
+        description: Manual comparison provider.
+        type: choice
+        default: codebuild
+        options: [codebuild, hosted]
+      cache_enabled:
+        description: Cache the pnpm store; disable for the no-cache comparison.
+        type: boolean
+        default: true
+      cache_epoch:
+        description: Provider-specific experiment namespace; reuse for warm samples.
+        type: string
+        default: ''
       ref:
         description: Optional branch, tag, or commit to qualify; defaults to the dispatched commit.
         required: false
@@ -13,13 +26,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: i18n-semantic-e2e-manual-${{ inputs.ref || github.ref }}
+  group: i18n-semantic-e2e-manual-${{ inputs.ref || github.ref }}-${{ inputs.provider }}-${{ inputs.cache_enabled }}-${{ inputs.cache_epoch }}
   cancel-in-progress: true
 
 jobs:
   semantic-qualification:
     name: Manual Hermetic Semantic Qualification
-    runs-on: codebuild-tiangong-ci-next-docker-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ${{ inputs.provider == 'hosted' && 'ubuntu-latest' || format('codebuild-tiangong-ci-next-docker-{0}-{1}', github.run_id, github.run_attempt) }}
     timeout-minutes: 90
 
     steps:
@@ -29,12 +42,22 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
 
+      - name: Bind comparison cache namespace
+        if: inputs.cache_epoch != ''
+        env:
+          EXPECTED_SHA: ${{ inputs.ref }}
+          BENCHMARK_PROVIDER: ${{ inputs.provider }}
+          CACHE_EPOCH: ${{ inputs.cache_epoch }}
+        run: >-
+          node -e "const fs=require('node:fs'),cp=require('node:child_process'); const sha=process.env.EXPECTED_SHA; if(!/^[0-9a-f]{40}$/.test(sha)||cp.execFileSync('git',['rev-parse','HEAD'],{encoding:'utf8'}).trim()!==sha) throw Error('Exact candidate mismatch'); fs.mkdirSync('.local/test-logs',{recursive:true}); fs.writeFileSync('.local/test-logs/ci-benchmark-cache-key',Buffer.concat([fs.readFileSync('pnpm-lock.yaml'),Buffer.from(JSON.stringify({provider:process.env.BENCHMARK_PROVIDER,epoch:process.env.CACHE_EPOCH}))]));"
+
       - name: Set up pnpm and Node.js
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
           version: 11.24.0
           runtime: node@24.19.0
-          cache: true
+          cache: ${{ inputs.cache_enabled }}
+          cache-dependency-path: ${{ inputs.cache_epoch != '' && '.local/test-logs/ci-benchmark-cache-key' || 'pnpm-lock.yaml' }}
           install: false
 
       - name: Install dependencies

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   release-gate:
     name: Release Gate
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Check out Git repository
@@ -97,7 +97,7 @@ jobs:
   release-proof:
     name: Aggregate Exact Release Proof
     needs: release-gate
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Check out exact candidate

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -25,7 +25,7 @@ jobs:
     name: Release Candidate Context
     if: >-
       github.event.pull_request.base.ref == 'dev' && contains(github.event.pull_request.body || '', 'tiangong-next-release-automation:v2')
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       release_base: ${{ steps.context.outputs.release_base }}
       candidate_base: ${{ steps.context.outputs.candidate_base }}
@@ -65,7 +65,7 @@ jobs:
   main-candidate:
     name: Main Candidate / Release Gate
     if: github.event.pull_request.base.ref == 'main'
-    runs-on: ubuntu-latest
+    runs-on: codebuild-tiangong-ci-next-linux-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Check out exact main candidate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,9 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-09-06
-lastReviewedCommit: 32758423c199da08cf1a9c26c5e2dba5be6c8f69
-lastReviewedNote: 'Reviewed for Next #1035 after Edge #407/#409 and root #1021/#1022: import exact Edge main ceff9c4 with legacy RPC/fallback compatibility; Database e988 snapshot and restore proof remain unchanged. Both pin contracts advance together; the normal committed push owns fresh full-gate proof.'
+lastReviewedAt: 2026-09-08
+lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ checkPaths:
   - .nvmrc
   - .husky/pre-push
   - .github/workflows/**
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedAt: 2026-09-09
+lastReviewedCommit: 86a5075e35e01f6e2aa6137a8510afa1b68a7f22
 lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -42,9 +42,9 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .github/workflows/build.yml
   - .nvmrc
-lastReviewedAt: 2026-09-06
-lastReviewedCommit: 32758423c199da08cf1a9c26c5e2dba5be6c8f69
-lastReviewedNote: 'Reviewed for Next #1035 after Edge #407/#409 and root #1021/#1022: import exact Edge main ceff9c4 with legacy RPC/fallback compatibility; Database e988 snapshot and restore proof remain unchanged. Both pin contracts advance together; the normal committed push owns fresh full-gate proof.'
+lastReviewedAt: 2026-09-08
+lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 
 # Development Bootstrap

--- a/DEV.md
+++ b/DEV.md
@@ -42,8 +42,8 @@ checkPaths:
   - .github/workflows/release-readiness.yml
   - .github/workflows/build.yml
   - .nvmrc
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedAt: 2026-09-09
+lastReviewedCommit: 86a5075e35e01f6e2aa6137a8510afa1b68a7f22
 lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -56,8 +56,8 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .github/workflows/build.yml
   - package.json
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedAt: 2026-09-09
+lastReviewedCommit: 86a5075e35e01f6e2aa6137a8510afa1b68a7f22
 lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 baselineObservedAt: 2026-07-18
 related:

--- a/docs/agents/i18n-language-delivery-goal.md
+++ b/docs/agents/i18n-language-delivery-goal.md
@@ -56,9 +56,9 @@ checkPaths:
   - .github/workflows/i18n-semantic-e2e.yml
   - .github/workflows/build.yml
   - package.json
-lastReviewedAt: 2026-09-01
-lastReviewedCommit: f92522afb8bdcd7681d004d5792e108528ec86a9
-lastReviewedNote: 'Reviewed for Next Issue #991: the correction ledger now records intentional baseline-message retirement without mutating frozen historical evidence or retaining dead runtime copy.'
+lastReviewedAt: 2026-09-08
+lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 baselineObservedAt: 2026-07-18
 related:
   - ../../AGENTS.md

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -42,9 +42,9 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-09-06
-lastReviewedCommit: 32758423c199da08cf1a9c26c5e2dba5be6c8f69
-lastReviewedNote: 'Reviewed for Next #1035 after Edge #407/#409 and root #1021/#1022: import exact Edge main ceff9c4 with legacy RPC/fallback compatibility; Database e988 snapshot and restore proof remain unchanged. Both pin contracts advance together; the normal committed push owns fresh full-gate proof.'
+lastReviewedAt: 2026-09-08
+lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 
 # Pre-Push Gate Policy

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -42,8 +42,8 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/reference-data/**
   - .github/workflows/**
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedAt: 2026-09-09
+lastReviewedCommit: 86a5075e35e01f6e2aa6137a8510afa1b68a7f22
 lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -43,9 +43,9 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-09-06
-lastReviewedCommit: 32758423c199da08cf1a9c26c5e2dba5be6c8f69
-lastReviewedNote: 'Reviewed for Next #1035 after Edge #407/#409 and root #1021/#1022: import exact Edge main ceff9c4 with legacy RPC/fallback compatibility; Database e988 snapshot and restore proof remain unchanged. Both pin contracts advance together; the normal committed push owns fresh full-gate proof.'
+lastReviewedAt: 2026-09-08
+lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 related:
   - ../AGENTS.md
   - ../.docpact/config.yaml
@@ -193,3 +193,9 @@ Every PR note for this repo must state:
 4. whether `pnpm prepush:gate` ran
 5. whether any required proof lives in another repo
 6. for semantic localization E2E, which browser/trust boundary ran and, for an authenticated run, the non-secret `created/cleaned/leaked` counts
+
+## CodeBuild migration qualification
+
+Non-macOS workflows route to repository-scoped ephemeral CodeBuild projects; macOS ARM64 remains GitHub-hosted. The Linux, ARM64 and Windows Electron entries retain their existing commands and architecture matrix. Semantic E2E uses the dedicated privileged Docker project. Runner labels bind the GitHub run ID and attempt; no hosted Linux/Windows fallback is configured.
+
+Before merging the runner migration, record an exact candidate's full local push gate and remote evidence for workflow checkout/toolchain/artifacts, Linux/ARM/Windows native packaging, semantic Docker execution, cancellation and CodeBuild build IDs. Keep release proof, production reference-data gates, permissions and secrets intact. Do not trigger a production deployment or publish a release merely to test runner setup. AWS resource configuration and admission belong to tiangong-aws; Next owns executable workflows and proof.

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -43,8 +43,8 @@ checkPaths:
   - scripts/typescript-native-parser.*
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedAt: 2026-09-09
+lastReviewedCommit: 86a5075e35e01f6e2aa6137a8510afa1b68a7f22
 lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 related:
   - ../AGENTS.md
@@ -199,3 +199,9 @@ Every PR note for this repo must state:
 Non-macOS workflows route to repository-scoped ephemeral CodeBuild projects; macOS ARM64 remains GitHub-hosted. The Linux, ARM64 and Windows Electron entries retain their existing commands and architecture matrix. Semantic E2E uses the dedicated privileged Docker project. Runner labels bind the GitHub run ID and attempt; no hosted Linux/Windows fallback is configured.
 
 Before merging the runner migration, record an exact candidate's full local push gate and remote evidence for workflow checkout/toolchain/artifacts, Linux/ARM/Windows native packaging, semantic Docker execution, cancellation and CodeBuild build IDs. Keep release proof, production reference-data gates, permissions and secrets intact. Do not trigger a production deployment or publish a release merely to test runner setup. AWS resource configuration and admission belong to tiangong-aws; Next owns executable workflows and proof.
+
+## Manual CI timing comparison
+
+The manual `ai-doc-lint.yml` and `i18n-semantic-e2e.yml` workflows accept `provider=hosted|codebuild`, `cache_enabled=true|false`, `ref=<exact candidate SHA>` and `cache_epoch=<experiment namespace>`. Defaults preserve CodeBuild and caching. A nonempty cache epoch requires a matching exact 40-character candidate and produces a provider-specific dependency cache key. Use different epochs for cold samples and the same epoch for warm samples; keep doc lint and semantic experiments in separate epochs to avoid competing cache writers. Semantic concurrency groups include provider/cache/epoch so paired experiments do not cancel one another.
+
+Both providers run the candidate's original full commands and qualification proof verification. This first experiment changes only runner selection and store caching; no test, worker count, fixture, skip policy, coverage threshold, release or deployment behavior changes. Compare full job timestamps including post-action caching and initial dispatch delay, and retain logs plus the immutable proof artifacts. Benchmark success is not native packaging qualification or release readiness.

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -43,9 +43,9 @@ checkPaths:
   - pnpm-lock.yaml
   - pnpm-workspace.yaml
   - Dockerfile.app
-lastReviewedAt: 2026-09-06
-lastReviewedCommit: 32758423c199da08cf1a9c26c5e2dba5be6c8f69
-lastReviewedNote: 'Reviewed for Next #1035 after Edge #407/#409 and root #1021/#1022: import exact Edge main ceff9c4 with legacy RPC/fallback compatibility; Database e988 snapshot and restore proof remain unchanged. Both pin contracts advance together; the normal committed push owns fresh full-gate proof.'
+lastReviewedAt: 2026-09-08
+lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 
 # Testing Strategy

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -43,8 +43,8 @@ checkPaths:
   - pnpm-lock.yaml
   - pnpm-workspace.yaml
   - Dockerfile.app
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedAt: 2026-09-09
+lastReviewedCommit: 86a5075e35e01f6e2aa6137a8510afa1b68a7f22
 lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -40,9 +40,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-06
-lastReviewedCommit: 32758423c199da08cf1a9c26c5e2dba5be6c8f69
-lastReviewedNote: 'Reviewed for Next #1035 after Edge #407/#409 and root #1021/#1022: import exact Edge main ceff9c4 with legacy RPC/fallback compatibility; Database e988 snapshot and restore proof remain unchanged. Both pin contracts advance together; the normal committed push owns fresh full-gate proof.'
+lastReviewedAt: 2026-09-08
+lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 
 # Testing Execution State

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -40,8 +40,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedAt: 2026-09-09
+lastReviewedCommit: 86a5075e35e01f6e2aa6137a8510afa1b68a7f22
 lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -42,9 +42,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-06
-lastReviewedCommit: 32758423c199da08cf1a9c26c5e2dba5be6c8f69
-lastReviewedNote: 'Reviewed for Next #1035 after Edge #407/#409 and root #1021/#1022: import exact Edge main ceff9c4 with legacy RPC/fallback compatibility; Database e988 snapshot and restore proof remain unchanged. Both pin contracts advance together; the normal committed push owns fresh full-gate proof.'
+lastReviewedAt: 2026-09-08
+lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 
 # Testing Patterns Reference

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -42,8 +42,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedAt: 2026-09-09
+lastReviewedCommit: 86a5075e35e01f6e2aa6137a8510afa1b68a7f22
 lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -39,8 +39,8 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-08
-lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedAt: 2026-09-09
+lastReviewedCommit: 86a5075e35e01f6e2aa6137a8510afa1b68a7f22
 lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -39,9 +39,9 @@ checkPaths:
   - .github/workflows/build.yml
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
-lastReviewedAt: 2026-09-06
-lastReviewedCommit: 32758423c199da08cf1a9c26c5e2dba5be6c8f69
-lastReviewedNote: 'Reviewed for Next #1035 after Edge #407/#409 and root #1021/#1022: import exact Edge main ceff9c4 with legacy RPC/fallback compatibility; Database e988 snapshot and restore proof remain unchanged. Both pin contracts advance together; the normal committed push owns fresh full-gate proof.'
+lastReviewedAt: 2026-09-08
+lastReviewedCommit: 5fe90293372adb1ba25fbf2d7dda06ba99bd94e9
+lastReviewedNote: 'Reviewed for Next #1040: CodeBuild runner routing retains workflow steps, release proof, native platform coverage and semantic Docker qualification; AWS owns runner resources and admission.'
 ---
 
 # Testing Troubleshooting


### PR DESCRIPTION
## Problem and change

Move non-macOS Next Actions jobs to repository-scoped CodeBuild projects while retaining GitHub orchestration, release proof, permissions, dependencies, native platform matrix and all existing test commands. macOS ARM64 stays GitHub-hosted. Semantic E2E uses the dedicated privileged Docker project; Linux/ARM/Windows packaging uses separate projects.

## Validation

Exact candidate 86a5075e35e01f6e2aa6137a8510afa1b68a7f22 passed the checked-push full local gate:
- strict Docpact and enforced documentation lint;
- LCIA/reference-resource verification, lint and typecheck;
- 47 isolated pre-push receipt tests;
- 443 coverage suites / 5,996 tests;
- all 484 tracked source files at 100% statements/branches/functions/lines.

SSH transport closed after the gate; repository-generated bounded push:retry preserves exact-head proof without bypassing the gate.

## Remaining verification

AWS #46 has connected all four Next projects. The maintainer created the canonical branch and dispatched both workflows at exact candidate `86a5075e35e01f6e2aa6137a8510afa1b68a7f22`:
- CodeBuild Linux documentation check passed in 2m10s: https://github.com/linancn/tiangong-lca-next/actions/runs/34242905869.
- Dedicated CodeBuild Docker semantic qualification passed in 25m24s, including complete qualification (23m27s), proof verification and artifact upload: https://github.com/linancn/tiangong-lca-next/actions/runs/34242949313.

Native Linux/ARM/Windows CodeBuild packaging remains unverified. These two successful runs do not establish native packaging compatibility. Do not trigger production deployment or package publication merely to test runners. This fork PR targets dev.

No test inventory, coverage threshold, deployment order or release-proof requirement is relaxed. Merge into dev is repository delivery only; promotion and exact main-eligible workspace integration remain separate.

Closes #1040


## Performance-first experiment entry
Workflow revision `46d6ce1de5ba756ee6bfdb4fd84a4c2b9a348bcf` adds manual provider/cache/epoch controls to the two existing validation workflows. Both providers can execute unchanged exact candidate `86a5075e35e01f6e2aa6137a8510afa1b68a7f22`. Full checked-push gate passed again (484 source files at 100%); the repository receipt-bound retry completed the fork push after SSH transport closed. Maintainer dispatch instructions: https://github.com/linancn/tiangong-lca-next/pull/1041#issuecomment-5594286320. No candidate tests, worker count, proof requirements or production workflow behavior changed. New paired benchmarks have not yet run; do not merge solely because runner connectivity passed.
