### PR TITLE
chore: prepare v0.0.104 on dev

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-09-13"
-lastReviewedCommit: "0b0589cb13a618070bd0033f7294a6272d7ecefc"
+lastReviewedCommit: "490df6476a1b7ca19c2d092f86636d52b9bdf637"
 lastReviewedNote: 'Reviewed for platform #1057: deterministic release prepare-only handoff preserves candidate and promotion gates; direct organization and personal fork PR identity, bounded lookup and body-file contracts are documented. Existing quality thresholds and ownership remain unchanged.'
 
 # Keep path-level ownership, routing intents, and governed-doc rules here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ checkPaths:
   - .husky/pre-push
   - .github/workflows/**
 lastReviewedAt: 2026-09-13
-lastReviewedCommit: 89575d9b6261133d499a5764505a9643ccfa56e4
+lastReviewedCommit: 490df6476a1b7ca19c2d092f86636d52b9bdf637
 lastReviewedNote: 'Reviewed for platform #1062: the Gitleaks Security Scan workflow (.github/workflows/gitleaks.yml), its dedicated config (.gitleaks.toml) and ignore file (.gitleaksignore) are removed entirely; no CLI replacement is introduced. Docpact governance references to those files are cleaned. Package version, dependencies, lock, build/lint/type/coverage/release-proof gates and other workflows are unchanged.'
 related:
   - .docpact/config.yaml

--- a/DEV.md
+++ b/DEV.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/build.yml
   - .nvmrc
 lastReviewedAt: 2026-09-13
-lastReviewedCommit: 89575d9b6261133d499a5764505a9643ccfa56e4
+lastReviewedCommit: 490df6476a1b7ca19c2d092f86636d52b9bdf637
 lastReviewedNote: 'Reviewed for platform #1062: the Gitleaks Security Scan workflow (.github/workflows/gitleaks.yml), its dedicated config (.gitleaks.toml) and ignore file (.gitleaksignore) are removed entirely; no CLI replacement is introduced. Docpact governance references to those files are cleaned. Package version, dependencies, lock, build/lint/type/coverage/release-proof gates and other workflows are unchanged.'
 ---
 

--- a/docs/agents/prepush-gate-policy.md
+++ b/docs/agents/prepush-gate-policy.md
@@ -43,7 +43,7 @@ checkPaths:
   - scripts/reference-data/**
   - .github/workflows/**
 lastReviewedAt: 2026-09-13
-lastReviewedCommit: 89575d9b6261133d499a5764505a9643ccfa56e4
+lastReviewedCommit: 490df6476a1b7ca19c2d092f86636d52b9bdf637
 lastReviewedNote: 'Reviewed for platform #1062: user-requested Gitleaks Action retirement removes its workflow and dedicated configuration. All other build, lint, type, coverage, release-proof and branch gates remain unchanged; no CLI replacement is added.'
 ---
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -44,7 +44,7 @@ checkPaths:
   - scripts/i18n/locale-delivery.mjs
   - .github/workflows/**
 lastReviewedAt: 2026-09-13
-lastReviewedCommit: 89575d9b6261133d499a5764505a9643ccfa56e4
+lastReviewedCommit: 490df6476a1b7ca19c2d092f86636d52b9bdf637
 lastReviewedNote: 'Reviewed for platform #1062: user-requested Gitleaks Action retirement removes its workflow and dedicated configuration. All other build, lint, type, coverage, release-proof and branch gates remain unchanged; no CLI replacement is added.'
 related:
   - ../AGENTS.md

--- a/docs/agents/test_improvement_plan.md
+++ b/docs/agents/test_improvement_plan.md
@@ -44,7 +44,7 @@ checkPaths:
   - pnpm-workspace.yaml
   - Dockerfile.app
 lastReviewedAt: 2026-09-13
-lastReviewedCommit: 89575d9b6261133d499a5764505a9643ccfa56e4
+lastReviewedCommit: 490df6476a1b7ca19c2d092f86636d52b9bdf637
 lastReviewedNote: 'Reviewed for platform #1062: user-requested Gitleaks Action retirement removes its workflow and dedicated configuration. All other build, lint, type, coverage, release-proof and branch gates remain unchanged; no CLI replacement is added.'
 ---
 

--- a/docs/agents/test_todo_list.md
+++ b/docs/agents/test_todo_list.md
@@ -41,7 +41,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-13
-lastReviewedCommit: 89575d9b6261133d499a5764505a9643ccfa56e4
+lastReviewedCommit: 490df6476a1b7ca19c2d092f86636d52b9bdf637
 lastReviewedNote: 'Reviewed for platform #1062: user-requested Gitleaks Action retirement removes its workflow and dedicated configuration. All other build, lint, type, coverage, release-proof and branch gates remain unchanged; no CLI replacement is added.'
 ---
 

--- a/docs/agents/testing-patterns.md
+++ b/docs/agents/testing-patterns.md
@@ -43,7 +43,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-13
-lastReviewedCommit: 89575d9b6261133d499a5764505a9643ccfa56e4
+lastReviewedCommit: 490df6476a1b7ca19c2d092f86636d52b9bdf637
 lastReviewedNote: 'Reviewed for platform #1062: user-requested Gitleaks Action retirement removes its workflow and dedicated configuration. All other build, lint, type, coverage, release-proof and branch gates remain unchanged; no CLI replacement is added.'
 ---
 

--- a/docs/agents/testing-troubleshooting.md
+++ b/docs/agents/testing-troubleshooting.md
@@ -40,7 +40,7 @@ checkPaths:
   - .github/workflows/release-gate.yml
   - .github/workflows/release-readiness.yml
 lastReviewedAt: 2026-09-13
-lastReviewedCommit: 89575d9b6261133d499a5764505a9643ccfa56e4
+lastReviewedCommit: 490df6476a1b7ca19c2d092f86636d52b9bdf637
 lastReviewedNote: 'Reviewed for platform #1062: user-requested Gitleaks Action retirement removes its workflow and dedicated configuration. All other build, lint, type, coverage, release-proof and branch gates remain unchanged; no CLI replacement is added.'
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiangong-lca-next",
-  "version": "0.0.103",
+  "version": "0.0.104",
   "packageManager": "pnpm@11.24.0",
   "private": true,
   "description": "An out-of-box LCA Data solution",


### PR DESCRIPTION
<!-- tiangong-next-release-automation:v2 issue=1064 version=0.0.104 dev-base=490df6476a1b7ca19c2d092f86636d52b9bdf637 main-base=de8620b1d844db240e563ad2aa034189ed0053d7 candidate=8b6eebb0ce44fb146fa4020750541622709c23ae -->

## Branch Contract

- base branch: `dev`
- validated environment: exact dev Release PR non-browser gate
- back-merge required after merge: No
- root workspace integration expected: after later dev-to-main promotion

## Linked Issue

Refs #1064

## Change Facts

- Prepare version `0.0.104` from exact dev base `490df6476a1b7ca19c2d092f86636d52b9bdf637`.
- Change only package.json.version and keep pnpm-lock.yaml byte-for-byte unchanged.
- Keep release proof external to Git and bind it to the exact main/dev bases, candidate SHA/tree, version, workflow run, and artifact.
- Record Docpact review evidence only after the command proves the candidate has no other semantic change.
- Reviewed paths:
  - `.docpact/config.yaml`
  - `AGENTS.md`
  - `DEV.md`
  - `docs/agents/prepush-gate-policy.md`
  - `docs/agents/repo-validation.md`
  - `docs/agents/test_improvement_plan.md`
  - `docs/agents/test_todo_list.md`
  - `docs/agents/testing-patterns.md`
  - `docs/agents/testing-troubleshooting.md`

## Validation Facts

- Candidate: `8b6eebb0ce44fb146fa4020750541622709c23ae`
- Main baseline: `de8620b1d844db240e563ad2aa034189ed0053d7`
- Release gate: `required_by_dev_release_candidate_gate`; static preflight: `passed`
- Docpact automatic-review status: `completed`
- Docpact checked the complete main-to-candidate promotion range before the dev PR was created.
- The managed candidate push ran only structural/static checks; this PR owns one non-browser full release gate and its exact proof.
- Browser E2E is not evaluated or required by this PR. Run the manual hermetic workflow on the open business PR before release-to-dev when the change risk warrants browser evidence.

## Risks And Follow-Up

- Merge only after the exact Release Candidate release proof succeeds, then run the deterministic dev-to-main promotion command with this PR number.

Closes tiangong-lca/platform#1064
